### PR TITLE
Handle multiple calls to next()

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -1,40 +1,38 @@
 'use strict';
 
-async function dispatch(middleware, state, i = 0) {
+async function dispatch(middleware, event, context, i = 0) {
 	const fn = middleware[i] || Function.prototype;
-	const next = async (err, context, event) => {
+	let prevResult;
+	const next = async (err, nxtContext, nxtEvent) => {
 		if (err) {
 			throw err;
 		}
 
-		if (context !== undefined && context !== null) {
-			state.context = context;
+		const result = await dispatch(middleware, nxtEvent || event, nxtContext || context, i + 1);
+
+		// Save result if one was passed
+		if (result !== undefined) {
+			prevResult = result;
 		}
 
-		if (event !== undefined && event !== null) {
-			state.event = event;
-		}
-
-		await dispatch(middleware, state, i + 1);
-
-		return state.result;
+		return result;
 	};
 
-	const result = await fn(state.event, state.context, next);
+	const result = await fn(event, context, next);
 
-	if (result !== undefined) {
-		state.result = result;
+	// Use result from previous middleware if this one didn't pass back a result
+	if (result === undefined) {
+		return prevResult;
 	}
 
-	return state;
+	return result;
 }
 
 module.exports = function () {
 	const middleware = [];
 
 	const handler = async (event, context) => {
-		const { result } = await dispatch(middleware, { event, context });
-		return result;
+		return dispatch(middleware, event, context);
 	};
 
 	handler.use = mw => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alpha-lambda/handler",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alpha-lambda/handler",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Middleware pipeline for AWS Lambda handlers",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Had to remove the state object, since multiple next calls would override the state.result field.